### PR TITLE
feat: Add missing buttons to mobile navigation

### DIFF
--- a/src/components/sections/Navbar.astro
+++ b/src/components/sections/Navbar.astro
@@ -271,6 +271,86 @@ const simpleMenuItems: Array<{ text: string; href: string }> = [
                     </a>
                   ))
                 }
+
+                <!-- Mobile-only buttons (hidden on desktop) -->
+                <div class="border-t border-gray-200 pt-4 xl:hidden">
+                  <!-- Contact/Report Button for Mobile -->
+                  <a
+                    href={addLanguageToPath("/contact", currentLang)}
+                    class="flex items-center rounded-lg bg-teal-600 p-3 font-medium text-white transition-opacity duration-200 hover:bg-teal-700 focus:bg-teal-700 focus:outline-hidden"
+                  >
+                    <span class="mr-2">📝</span>
+                    {getTranslation("nav.report", currentLang)}
+                  </a>
+
+                  <!-- Weather Button for Mobile -->
+                  {
+                    currentTemp ? (
+                      <a
+                        href={addLanguageToPath("/weather", currentLang)}
+                        class={`mt-2 flex items-center gap-2 rounded-lg border p-3 font-medium transition-colors ${
+                          typhoonWarning.signal
+                            ? `${typhoonWarning.color} hover:opacity-80`
+                            : "border-blue-200 bg-blue-50 text-blue-800 hover:bg-blue-100"
+                        }`}
+                      >
+                        {hasHighPriorityWarning && (
+                          <span class="animate-pulse text-red-500">⚠️</span>
+                        )}
+                        <span>{getWeatherIcon(weatherIconCode)}</span>
+                        <span>{currentTemp}°C</span>
+                        {typhoonWarning.signal && (
+                          <span class="ml-auto border-l pl-2 text-sm font-bold">
+                            {typhoonWarning.signal}
+                          </span>
+                        )}
+                        <span class="ml-auto text-sm">
+                          {currentLang === "ko" ? "날씨 보기" : "View Weather"}
+                        </span>
+                      </a>
+                    ) : (
+                      <a
+                        href={addLanguageToPath("/weather", currentLang)}
+                        class="mt-2 flex items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 p-3 font-medium text-gray-600 transition-colors hover:bg-gray-100"
+                      >
+                        {hasHighPriorityWarning && (
+                          <span class="animate-pulse text-red-500">⚠️</span>
+                        )}
+                        <span>🌤️</span>
+                        <span>{currentLang === "ko" ? "날씨 보기" : "View Weather"}</span>
+                      </a>
+                    )
+                  }
+
+                  <!-- Language Toggle for Mobile -->
+                  <div class="mt-3">
+                    <div class="text-sm font-medium text-gray-700 mb-2">
+                      {currentLang === "ko" ? "언어 선택" : "Language"}
+                    </div>
+                    <div class="flex gap-2">
+                      <a
+                        href={addLanguageToPath(currentPath, "ko")}
+                        class={`flex-1 px-4 py-2 text-center text-sm rounded-lg font-medium transition-colors ${
+                          currentLang === "ko" 
+                            ? "bg-teal-600 text-white" 
+                            : "bg-gray-200 text-gray-700 hover:bg-gray-300"
+                        }`}
+                      >
+                        한국어
+                      </a>
+                      <a
+                        href={addLanguageToPath(currentPath, "en")}
+                        class={`flex-1 px-4 py-2 text-center text-sm rounded-lg font-medium transition-colors ${
+                          currentLang === "en" 
+                            ? "bg-teal-600 text-white" 
+                            : "bg-gray-200 text-gray-700 hover:bg-gray-300"
+                        }`}
+                      >
+                        English
+                      </a>
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
- Fix mobile navigation missing 건의하기 (Report/Contact) button
- Add weather information display to mobile menu with typhoon warnings
- Include Korean/English language toggle in mobile navigation
- Improve mobile UX with proper touch targets and spacing
- Add visual separation with border and clear section labeling
- Maintain feature parity between desktop and mobile navigation

Mobile menu now includes:
- Contact/Report button with prominent styling
- Real-time weather display with temperature and warnings
- Emergency alerts for dangerous weather conditions
- Language selection with clear Korean/English options
- Mobile-optimized button sizes and layout

Fixes: Mobile users can now access all navigation features that were previously desktop-only